### PR TITLE
Updated duckdb-rs and rusqlite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,15 +418,15 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "duckdb"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "326e8f84acb4d57c4025637f77e89dc3eee0e25b3a79c21cfd8b72db5ecd3c97"
+checksum = "91064bc413bb2db36005516878ab585da67e9b093956e1af1b6e036a2a9cfa4f"
 dependencies = [
  "arrow",
  "cast",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.8.4",
  "libduckdb-sys",
  "memchr",
  "rust_decimal",
@@ -544,6 +544,15 @@ name = "hashlink"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.3",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692eaaf7f7607518dd3cef090f1474b61edc5301d8012f09579920df68b725ee"
 dependencies = [
  "hashbrown 0.14.3",
 ]
@@ -683,9 +692,9 @@ checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "libduckdb-sys"
-version = "0.9.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666dbbb7ac31fc49fc2535df5d6efe9ce09815783a0ad98eea3564d2f0223974"
+checksum = "472e81a731bd70f22d81968fca6fb95bcce6ef5bda7e48b09574d41a6fda726b"
 dependencies = [
  "autocfg",
  "cc",
@@ -705,9 +714,9 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1020,14 +1029,14 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78046161564f5e7cd9008aff3b2990b3850dc8e0349119b98e8f251e099f24d"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
 dependencies = [
  "bitflags 2.4.2",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.9.0",
  "libsqlite3-sys",
  "smallvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rusqlite = { version = "0.30.0", features = ["bundled", "limits"] }
-duckdb = { version = "0.9.2", features = ["bundled"]}
+rusqlite = { version = "0.31.0", features = ["bundled", "limits"] }
+duckdb = { version = "0.10.1", features = ["bundled"]}

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,7 +239,7 @@ mod tests {
             // Attach to the SQLite DB
             conn.execute_batch("
             INSTALL sqlite;
-            ATTACH './db/sqlite_writer_duckdb_reader_with_wal.db' AS sqlite_db (TYPE SQLITE, READ_ONLY);
+            ATTACH './db/sqlite_writer_duckdb_reader_with_wal.db' AS sqlite_db (TYPE SQLITE, READ_ONLY, JOURNAL_MODE 'WAL');
             ").unwrap();
 
             // Count the rows
@@ -356,7 +356,7 @@ mod tests {
             conn.execute_batch(
                 "
             INSTALL sqlite;
-            ATTACH './db/duckdb_writer_duckdb_reader_with_wal.db' AS sqlite_db (TYPE SQLITE);
+            ATTACH './db/duckdb_writer_duckdb_reader_with_wal.db' AS sqlite_db (TYPE SQLITE, JOURNAL_MODE 'WAL');
             ",
             )
             .unwrap();
@@ -386,7 +386,7 @@ mod tests {
             // Attach to the SQLite DB
             conn.execute_batch("
             INSTALL sqlite;
-            ATTACH './db/duckdb_writer_duckdb_reader_with_wal.db' AS sqlite_db (TYPE SQLITE, READ_ONLY);
+            ATTACH './db/duckdb_writer_duckdb_reader_with_wal.db' AS sqlite_db (TYPE SQLITE, READ_ONLY, JOURNAL_MODE 'WAL');
             ").unwrap();
 
             // Count the rows


### PR DESCRIPTION
- Updated duckdb-rs to v0.10.1 to include the fix for https://github.com/duckdb/sqlite_scanner/issues/82
- Added JOURNAL_MODE 'WAL' when DuckDB attaches the SQLite database as documented in https://github.com/duckdb/sqlite_scanner/pull/83
- These two changes, however, did not seem to fix the concurrency errors documented in https://github.com/duckdb/sqlite_scanner/issues/82