### PR TITLE
Removed "bundled" from rusqlite to resolve concurrency issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,9 +604,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
 dependencies = [
  "libc",
 ]
@@ -718,7 +718,6 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
 dependencies = [
- "cc",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rusqlite = { version = "0.31.0", features = ["bundled", "limits"] }
+rusqlite = { version = "0.31.0", features = ["limits"] }
 duckdb = { version = "0.10.1", features = ["bundled"]}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This is a Rust project to exercise writing to a SQLite database using a SQLite client while concurrently reading from the same database using either a SQLite client or a DuckDB client in a variet of configurations (e.g., with and without a write-ahead log (WAL)).
 
-This project uses [Rusqlite](https://github.com/rusqlite/rusqlite) for the SQLite client. It uses [duckdb-rs](duckdb-rs) for the DuckDB client, which relies on the [sqlite_scanner](https://github.com/duckdb/sqlite_scanner) DuckDB extension.
+This project uses [Rusqlite](https://github.com/rusqlite/rusqlite) for the SQLite client. It uses [duckdb-rs](https://github.com/duckdb/duckdb-rs) for the DuckDB client, which relies on the [sqlite_scanner](https://github.com/duckdb/sqlite_scanner) DuckDB extension.
 
 You can control how long each test runs by editing the row count function:
 ```rust
@@ -17,12 +17,17 @@ You can control the amount of concurrency by editing how long each thread sleeps
 ```
 
 Run each test individually. For example:
-```
+```shell
 cargo test test_sqlite_writer_sqlite_reader_with_wal -- --nocapture
 ```
 
 To rerun a test, delete the corresponding files in the `db` directory before running the test:
-```
+```shell
 rm db/test_sqlite_writer_sqlite_reader_with_wal*
 cargo test test_sqlite_writer_sqlite_reader_with_wal -- --nocapture
+```
+
+To run all the tests:
+```shell
+make
 ```


### PR DESCRIPTION
Removing `bundled` makes the concurrency tests using SQLite and DuckDB pass.

The test `test_duckdb_writer_duckdb_reader_no_wal` fails with `database is locked` errors.

The test `test_duckdb_writer_duckdb_reader_with_wal` passes, but runs very slowly.